### PR TITLE
rename repo to go-server-sdk-redis-redigo

### DIFF
--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -2,5 +2,5 @@ template:
   name: go
 
 publications:
-  - url: https://pkg.go.dev/github.com/launchdarkly/go-server-sdk-redis
+  - url: https://pkg.go.dev/github.com/launchdarkly/go-server-sdk-redis-redigo
     description: documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing to this library
 
-The source code for this library is [here](https://github.com/launchdarkly/go-server-sdk-redis). We encourage pull-requests and other contributions from the community. Since this library is meant to be used in conjunction with the LaunchDarkly Go SDK, you may want to look at the [Go SDK source code](https://github.com/launchdarkly/go-server-sdk) and our [SDK contributor's guide](http://docs.launchdarkly.com/docs/sdk-contributors-guide).
+The source code for this library is [here](https://github.com/launchdarkly/go-server-sdk-redis-redigo). We encourage pull-requests and other contributions from the community. Since this library is meant to be used in conjunction with the LaunchDarkly Go SDK, you may want to look at the [Go SDK source code](https://github.com/launchdarkly/go-server-sdk) and our [SDK contributor's guide](http://docs.launchdarkly.com/docs/sdk-contributors-guide).
 
 ## Submitting bug reports and feature requests
  
-The LaunchDarkly SDK team monitors the [issue tracker](https://github.com/launchdarkly/go-server-sdk-redis/issues) in this repository. Bug reports and feature requests specific to this project should be filed in the issue tracker. The SDK team will respond to all newly filed issues within two business days.
+The LaunchDarkly SDK team monitors the [issue tracker](https://github.com/launchdarkly/go-server-sdk-redis-redigo/issues) in this repository. Bug reports and feature requests specific to this project should be filed in the issue tracker. The SDK team will respond to all newly filed issues within two business days.
  
 ## Submitting pull requests
  

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# LaunchDarkly Server-side SDK for Go - Redis integration
+# LaunchDarkly Server-side SDK for Go - Redis integration with Redigo client
 
-[![Circle CI](https://circleci.com/gh/launchdarkly/go-server-sdk-redis.svg?style=shield)](https://circleci.com/gh/launchdarkly/go-server-sdk-redis) [![Documentation](https://img.shields.io/static/v1?label=go.dev&message=reference&color=00add8)](https://pkg.go.dev/github.com/launchdarkly/go-server-sdk-redis)
+[![Circle CI](https://circleci.com/gh/launchdarkly/go-server-sdk-redis-redigo.svg?style=shield)](https://circleci.com/gh/launchdarkly/go-server-sdk-redis-redigo) [![Documentation](https://img.shields.io/static/v1?label=go.dev&message=reference&color=00add8)](https://pkg.go.dev/github.com/launchdarkly/go-server-sdk-redis-redigo)
 
-This library provides a [Redis](https://redis.io/)-backed persistence mechanism (data store) for the [LaunchDarkly Go SDK](https://github.com/launchdarkly/go-server-sdk), replacing the default in-memory data store. The Redis API implementation it uses is [Redigo](github.com/gomodule/redigo).
+This library provides a [Redis](https://redis.io/)-backed persistence mechanism (data store) for the [LaunchDarkly Go SDK](https://github.com/launchdarkly/go-server-sdk), replacing the default in-memory data store.
+
+The Redis API implementation it uses is [Redigo](github.com/gomodule/redigo). There are other Redis client implementations for Go; if LaunchDarkly SDK Redis integrations using other Redis clients are released, they will be in separate repositories.
 
 This version of the library requires at least version 5.0.0 of the LaunchDarkly Go SDK. In earlier Go SDK versions, the `ldredis` package was built into the SDK (`gopkg.in/launchdarkly/go-server-sdk.v4/ldredis`).
 
@@ -20,7 +22,7 @@ This assumes that you have already installed the LaunchDarkly Go SDK.
 import (
     ld "gopkg.in/launchdarkly/go-server-sdk.v5"
     "gopkg.in/launchdarkly/go-server-sdk.v5/ldcomponents"
-    ldredis "github.com/launchdarkly/go-server-sdk-redis"
+    ldredis "github.com/launchdarkly/go-server-sdk-redis-redigo"
 )
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/launchdarkly/go-server-sdk-redis
+module github.com/launchdarkly/go-server-sdk-redis-redigo
 
 go 1.13
 

--- a/package_info.go
+++ b/package_info.go
@@ -5,7 +5,7 @@
 //
 // To use the Redis data store with the LaunchDarkly client:
 //
-//     import ldredis "github.com/launchdarkly/go-server-sdk-redis"
+//     import ldredis "github.com/launchdarkly/go-server-sdk-redis-redigo"
 //
 //     config := ld.Config{
 //         DataStore: ldcomponents.PersistentDataStore(ldredis.DataStore()),

--- a/redis_builder.go
+++ b/redis_builder.go
@@ -92,7 +92,7 @@ func (b *DataStoreBuilder) Pool(pool *r.Pool) *DataStoreBuilder {
 //
 //     import (
 //         redigo "github.com/garyburd/redigo/redis"
-//         ldredis "github.com/launchdarkly/go-server-sdk-redis"
+//         ldredis "github.com/launchdarkly/go-server-sdk-redis-redigo"
 //     )
 //     config.DataSource = ldcomponents.PersistentDataStore(
 //         ldredis.DataStore().DialOptions(redigo.DialPassword("verysecure123")),


### PR DESCRIPTION
The repository has already been renamed; this fixes references to the repo name in readme/comment text.