### PR TITLE
Enhancement: Allow a flexible Redis pool interface

### DIFF
--- a/redis_builder.go
+++ b/redis_builder.go
@@ -87,6 +87,14 @@ func (b *DataStoreBuilder) Pool(pool *r.Pool) *DataStoreBuilder {
 	return b
 }
 
+// PoolInterface works on the same way as Pool, but allows injecting an
+// interface that represents the Redis pool. This is useful to wrap Redis
+// connections, adding custom behaviours.
+func (b *DataStoreBuilder) PoolInterface(pool Pool) *DataStoreBuilder {
+	b.pool = pool
+	return b
+}
+
 // DialOptions specifies any of the advanced Redis connection options supported by Redigo, such as
 // DialPassword.
 //

--- a/redis_builder.go
+++ b/redis_builder.go
@@ -42,7 +42,7 @@ func DataStore() *DataStoreBuilder {
 // actual data store; that will be done by the SDK.
 type DataStoreBuilder struct {
 	prefix      string
-	pool        *r.Pool
+	pool        Pool
 	url         string
 	dialOptions []r.DialOption
 }
@@ -114,4 +114,15 @@ func (b *DataStoreBuilder) CreatePersistentDataStore(
 // DescribeConfiguration is used internally by the SDK to inspect the configuration.
 func (b *DataStoreBuilder) DescribeConfiguration() ldvalue.Value {
 	return ldvalue.String("Redis")
+}
+
+// Pool maintains a pool of connections. The application calls the Get method to
+// get a connection from the pool and the connection's Close method to return
+// the connection's resources to the pool.
+//
+// It's available as an interface so the caller can easily add wrappers around
+// Redis layers.
+type Pool interface {
+	Get() r.Conn
+	Close() error
 }

--- a/redis_builder_test.go
+++ b/redis_builder_test.go
@@ -34,6 +34,12 @@ func TestDataSourceBuilder(t *testing.T) {
 		assert.Equal(t, p, b.pool)
 	})
 
+	t.Run("PoolInterface", func(t *testing.T) {
+		p := &myCustomPool{Pool: r.Pool{MaxActive: 999}}
+		b := DataStore().PoolInterface(p)
+		assert.Equal(t, p, b.pool)
+	})
+
 	t.Run("Prefix", func(t *testing.T) {
 		b := DataStore().Prefix("p")
 		assert.Equal(t, "p", b.prefix)
@@ -50,4 +56,22 @@ func TestDataSourceBuilder(t *testing.T) {
 		b.URL("")
 		assert.Equal(t, DefaultURL, b.url)
 	})
+}
+
+// myCustomPool is an example of a Redis pool wrapper.
+type myCustomPool struct {
+	r.Pool
+
+	getCount   int
+	closeCount int
+}
+
+func (m *myCustomPool) Get() r.Conn {
+	m.getCount++
+	return m.Pool.Get()
+}
+
+func (m *myCustomPool) Close() error {
+	m.closeCount++
+	return m.Pool.Close()
 }

--- a/redis_impl.go
+++ b/redis_impl.go
@@ -12,7 +12,7 @@ import (
 // Internal implementation of the PersistentDataStore interface for Redis.
 type redisDataStoreImpl struct {
 	prefix     string
-	pool       *r.Pool
+	pool       Pool
 	loggers    ldlog.Loggers
 	testTxHook func()
 }


### PR DESCRIPTION
The current code expects a `*redis.Pool` type to be injected, and that becomes an issue when you need to wrap Redis connection layers to some specific logic.

Changing the pool type to an interface solves the issue allowing more flexible strategies. For example:

```go
type MyPool struct {
  r.Pool
}

func (m MyPool) Get() r.Conn {
  return MyConn {
    Conn: m.Pool.Get(),
  }
}

type MyConn struct {
  r.Conn
}

func (m MyConn) Do(commandName string, args ...interface{}) (reply interface{}, err error) {
  log.Println("some custom logic")
  return m.Conn.Do(commandName, args...)
}
```