### PR TITLE
redact password when logging Redis URL

### DIFF
--- a/redis_big_segments_impl.go
+++ b/redis_big_segments_impl.go
@@ -31,7 +31,7 @@ func newRedisBigSegmentStoreImpl(
 	impl.loggers.SetPrefix("RedisBigSegmentStore:")
 
 	if impl.pool == nil {
-		impl.loggers.Infof("Using URL: %s", builder.url)
+		logRedisURL(loggers, builder.url)
 		impl.pool = newPool(builder.url, builder.dialOptions)
 	}
 	return impl

--- a/redis_impl.go
+++ b/redis_impl.go
@@ -1,6 +1,7 @@
 package ldredis
 
 import (
+	"net/url"
 	"time"
 
 	r "github.com/gomodule/redigo/redis"
@@ -49,10 +50,18 @@ func newRedisDataStoreImpl(
 	impl.loggers.SetPrefix("RedisDataStore:")
 
 	if impl.pool == nil {
-		impl.loggers.Infof("Using URL: %s", builder.url)
+		logRedisURL(loggers, builder.url)
 		impl.pool = newPool(builder.url, builder.dialOptions)
 	}
 	return impl
+}
+
+func logRedisURL(loggers ldlog.Loggers, redisURL string) {
+	if parsed, err := url.Parse(redisURL); err == nil {
+		loggers.Infof("Using URL: %s", parsed.Redacted())
+	} else {
+		loggers.Errorf("Invalid Redis URL: %s", redisURL) // we can assume that the Redis client will also fail
+	}
 }
 
 func (store *redisDataStoreImpl) Init(allData []ldstoretypes.SerializedCollection) error {

--- a/redis_impl.go
+++ b/redis_impl.go
@@ -58,10 +58,22 @@ func newRedisDataStoreImpl(
 
 func logRedisURL(loggers ldlog.Loggers, redisURL string) {
 	if parsed, err := url.Parse(redisURL); err == nil {
-		loggers.Infof("Using URL: %s", parsed.Redacted())
+		loggers.Infof("Using URL: %s", urlToRedactedString(parsed))
 	} else {
 		loggers.Errorf("Invalid Redis URL: %s", redisURL) // we can assume that the Redis client will also fail
 	}
+}
+
+// Equivalent to URL.Redacted() in Go 1.15+; currently we still support Go 1.14
+func urlToRedactedString(parsed *url.URL) string {
+	if parsed != nil && parsed.User != nil {
+		if _, hasPW := parsed.User.Password(); hasPW {
+			transformed := *parsed
+			transformed.User = url.UserPassword(parsed.User.Username(), "xxxxx")
+			return transformed.String()
+		}
+	}
+	return parsed.String()
 }
 
 func (store *redisDataStoreImpl) Init(allData []ldstoretypes.SerializedCollection) error {

--- a/redis_logging_test.go
+++ b/redis_logging_test.go
@@ -1,0 +1,43 @@
+package ldredis
+
+import (
+	"testing"
+
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldlog"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldlogtest"
+	"gopkg.in/launchdarkly/go-server-sdk.v5/ldcomponents"
+	"gopkg.in/launchdarkly/go-server-sdk.v5/testhelpers"
+
+	"github.com/stretchr/testify/require"
+)
+
+func doStartupLoggingTest(t *testing.T, url string, expectedLogURL string) {
+	mockLog1 := ldlogtest.NewMockLog()
+	mockLog2 := ldlogtest.NewMockLog()
+	defer mockLog1.DumpIfTestFailed(t)
+	defer mockLog2.DumpIfTestFailed(t)
+	context1 := testhelpers.NewSimpleClientContext("sdk-key").
+		WithLogging(ldcomponents.Logging().Loggers(mockLog1.Loggers))
+	context2 := testhelpers.NewSimpleClientContext("sdk-key").
+		WithLogging(ldcomponents.Logging().Loggers(mockLog2.Loggers))
+
+	store1, err := DataStore().URL(url).CreatePersistentDataStore(context1)
+	require.NoError(t, err)
+	_ = store1.Close()
+	mockLog1.AssertMessageMatch(t, true, ldlog.Info, "Using URL: "+expectedLogURL)
+
+	store2, err := DataStore().URL(url).CreateBigSegmentStore(context2)
+	require.NoError(t, err)
+	_ = store2.Close()
+	mockLog2.AssertMessageMatch(t, true, ldlog.Info, "Using URL: "+expectedLogURL)
+}
+
+func TestURLAppearsInLogAtStartup(t *testing.T) {
+	doStartupLoggingTest(t, "redis://localhost:6379", "redis://localhost:6379")
+	doStartupLoggingTest(t, "redis://localhost:6379/1", "redis://localhost:6379/1")
+}
+
+func TestURLPasswordIsObfuscatedInLog(t *testing.T) {
+	doStartupLoggingTest(t, "redis://username@localhost:6379", "redis://username@localhost:6379")
+	doStartupLoggingTest(t, "redis://username:very-secret-password@localhost:6379", "redis://username:xxxxx@localhost:6379")
+}


### PR DESCRIPTION
This uses Go's standard `URL.Redacted()` method which replaces passwords with `xxxxx`.