### PR TITLE
fix: Reuse connection in Upsert to prevent deadlock

### DIFF
--- a/redis_impl.go
+++ b/redis_impl.go
@@ -100,7 +100,14 @@ func (store *redisDataStoreImpl) Get(
 ) (ldstoretypes.SerializedItemDescriptor, error) {
 	c := store.getConn()
 	defer c.Close() // nolint:errcheck
+	return store.getWithConn(c, kind, key)
+}
 
+func (store *redisDataStoreImpl) getWithConn(
+	c r.Conn,
+	kind ldstoretypes.DataKind,
+	key string,
+) (ldstoretypes.SerializedItemDescriptor, error) {
 	jsonStr, err := r.String(c.Do("HGET", store.featuresKey(kind), key))
 
 	if err != nil {
@@ -160,7 +167,7 @@ func (store *redisDataStoreImpl) Upsert(
 			store.testTxHook()
 		}
 
-		oldItem, err := store.Get(kind, key)
+		oldItem, err := store.getWithConn(c, kind, key)
 		if err != nil { // COVERAGE: can't cause an error here in unit tests
 			return false, err
 		}


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality [N/A]
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Describe the solution you've provided**
Upsert() has an incredibly obscure deadlock scenario. Consider the following:

Suppose you start 20 threads. Each of them starts inserting feature flags into Redis using Upsert.
There are 16 max Redis connections, so 16 of your 20 threads grab a connection at line 149 (`c := store.getConn()`). There are now 0 available connections.

Now, each thread calls `store.Get()`. At line 101, they once again call `c := store.getConn()`. However, there are zero connections, so they all wait. Now, all of our threads are blocked.

Due to the way we set up feature flags in our integration tests, when I tried increasing parallelism, this happened to me a fair amount! A stack trace from our test timeout showed that many Goroutines were blocked on `Get()`'s `c := store.getConn()`, at line 101, within `Upsert()`.

**Additional context**
Claude came up with this solution. I think it's _slightly_ ugly, because it adds a random helper function around a bunch of public interface methods, but I think it's a good solution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cc56491f540c838a44efcb1e8c565c5c2a66068f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->