### PR TITLE
Release Redis connections between Upsert retries

### DIFF
--- a/redis_impl.go
+++ b/redis_impl.go
@@ -152,63 +152,74 @@ func (store *redisDataStoreImpl) Upsert(
 ) (bool, error) {
 	baseKey := store.featuresKey(kind)
 	for {
-		// We accept that we can acquire multiple connections here and defer inside loop but we don't expect many
-		c := store.getConn()
-		defer c.Close() // nolint:errcheck
-
-		_, err := c.Do("WATCH", baseKey)
-		if err != nil {
-			return false, err
+		updated, retry, err := store.tryUpsert(kind, key, baseKey, newItem)
+		if !retry {
+			return updated, err
 		}
-
-		defer c.Send("UNWATCH") // nolint:errcheck // this should always succeed
-
-		if store.testTxHook != nil { // instrumentation for unit tests
-			store.testTxHook()
-		}
-
-		oldItem, err := store.getWithConn(c, kind, key)
-		if err != nil { // COVERAGE: can't cause an error here in unit tests
-			return false, err
-		}
-
-		// In this implementation, we have to parse the existing item in order to determine its version.
-		oldVersion := oldItem.Version
-		if oldItem.SerializedItem != nil {
-			parsed, _ := kind.Deserialize(oldItem.SerializedItem)
-			oldVersion = parsed.Version
-		}
-
-		if oldVersion >= newItem.Version {
-			updateOrDelete := "update"
-			if newItem.Deleted {
-				updateOrDelete = "delete"
-			}
-			if store.loggers.IsDebugEnabled() { // COVERAGE: tests don't verify debug logging
-				store.loggers.Debugf(`Attempted to %s key: %s version: %d in "%s" with a version that is the same or older: %d`,
-					updateOrDelete, key, oldVersion, kind, newItem.Version)
-			}
-			return false, nil
-		}
-
-		_ = c.Send("MULTI")
-		err = c.Send("HSET", baseKey, key, newItem.SerializedItem)
-		if err == nil {
-			var result interface{}
-			result, err = c.Do("EXEC")
-			if err == nil {
-				if result == nil {
-					// if exec returned nothing, it means the watch was triggered and we should retry
-					if store.loggers.IsDebugEnabled() { // COVERAGE: tests don't verify debug logging
-						store.loggers.Debug("Concurrent modification detected, retrying")
-					}
-					continue
-				}
-			}
-			return true, nil
-		}
-		return false, err // COVERAGE: can't cause an error here in unit tests
 	}
+}
+
+func (store *redisDataStoreImpl) tryUpsert(
+	kind ldstoretypes.DataKind,
+	key string,
+	baseKey string,
+	newItem ldstoretypes.SerializedItemDescriptor,
+) (bool, bool, error) {
+	c := store.getConn()
+	defer c.Close() // nolint:errcheck
+
+	_, err := c.Do("WATCH", baseKey)
+	if err != nil {
+		return false, false, err
+	}
+
+	defer c.Send("UNWATCH") // nolint:errcheck // this should always succeed
+
+	if store.testTxHook != nil { // instrumentation for unit tests
+		store.testTxHook()
+	}
+
+	oldItem, err := store.getWithConn(c, kind, key)
+	if err != nil { // COVERAGE: can't cause an error here in unit tests
+		return false, false, err
+	}
+
+	// In this implementation, we have to parse the existing item in order to determine its version.
+	oldVersion := oldItem.Version
+	if oldItem.SerializedItem != nil {
+		parsed, _ := kind.Deserialize(oldItem.SerializedItem)
+		oldVersion = parsed.Version
+	}
+
+	if oldVersion >= newItem.Version {
+		updateOrDelete := "update"
+		if newItem.Deleted {
+			updateOrDelete = "delete"
+		}
+		if store.loggers.IsDebugEnabled() { // COVERAGE: tests don't verify debug logging
+			store.loggers.Debugf(`Attempted to %s key: %s version: %d in "%s" with a version that is the same or older: %d`,
+				updateOrDelete, key, oldVersion, kind, newItem.Version)
+		}
+		return false, false, nil
+	}
+
+	_ = c.Send("MULTI")
+	err = c.Send("HSET", baseKey, key, newItem.SerializedItem)
+	if err == nil {
+		var result interface{}
+		result, err = c.Do("EXEC")
+		if err == nil {
+			if result == nil {
+				// if exec returned nothing, it means the watch was triggered and we should retry
+				if store.loggers.IsDebugEnabled() { // COVERAGE: tests don't verify debug logging
+					store.loggers.Debug("Concurrent modification detected, retrying")
+				}
+				return false, true, nil
+			}
+		}
+		return true, false, nil
+	}
+	return false, false, err // COVERAGE: can't cause an error here in unit tests
 }
 
 func (store *redisDataStoreImpl) IsInitialized() bool {

--- a/redis_impl_upsert_retry_test.go
+++ b/redis_impl_upsert_retry_test.go
@@ -13,6 +13,34 @@ import (
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 )
 
+func TestUpsertReleasesConnectionBeforeRetry(t *testing.T) {
+	pool := &singleActiveConnectionPool{
+		t: t,
+		connections: []*upsertTestConn{
+			{execReply: nil},
+			{execReply: []any{[]byte("OK")}},
+		},
+	}
+	loggers := ldlog.NewDisabledLoggers()
+	loggers.SetMinLevel(ldlog.Debug)
+	store := &redisDataStoreImpl{
+		prefix:  "test",
+		pool:    pool,
+		loggers: loggers,
+	}
+
+	updated, err := store.Upsert(ldstoreimpl.Features(), "flag-key", ldstoretypes.SerializedItemDescriptor{
+		Version:        1,
+		SerializedItem: []byte(`{"key":"flag-key","version":1}`),
+	})
+
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.Equal(t, 2, pool.getCount, "the nil EXEC response should cause exactly one retry")
+	require.Equal(t, 0, pool.activeCount, "all borrowed connections should be returned")
+	require.Equal(t, 1, pool.maxActiveCount, "a retry must not retain the previous connection")
+}
+
 func TestUpsertReturnsConnectionOnErrors(t *testing.T) {
 	watchErr := errors.New("WATCH failed")
 	hgetErr := errors.New("HGET failed")

--- a/redis_impl_upsert_retry_test.go
+++ b/redis_impl_upsert_retry_test.go
@@ -1,0 +1,167 @@
+package ldredis
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	r "github.com/gomodule/redigo/redis"
+	"github.com/stretchr/testify/require"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+)
+
+func TestUpsertReturnsConnectionOnErrors(t *testing.T) {
+	watchErr := errors.New("WATCH failed")
+	hgetErr := errors.New("HGET failed")
+	hsetErr := errors.New("HSET failed")
+
+	tests := []struct {
+		name string
+		conn *upsertTestConn
+		err  error
+	}{
+		{name: "watch", conn: &upsertTestConn{watchErr: watchErr}, err: watchErr},
+		{name: "read", conn: &upsertTestConn{hgetErr: hgetErr}, err: hgetErr},
+		{name: "write", conn: &upsertTestConn{hsetErr: hsetErr}, err: hsetErr},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pool := &singleActiveConnectionPool{t: t, connections: []*upsertTestConn{test.conn}}
+			store := &redisDataStoreImpl{prefix: "test", pool: pool, loggers: ldlog.NewDisabledLoggers()}
+
+			updated, err := store.Upsert(ldstoreimpl.Features(), "flag-key", ldstoretypes.SerializedItemDescriptor{
+				Version:        1,
+				SerializedItem: []byte("new"),
+			})
+
+			require.False(t, updated)
+			require.ErrorIs(t, err, test.err)
+			require.Equal(t, 1, test.conn.closeCount)
+			require.Zero(t, pool.activeCount)
+		})
+	}
+}
+
+func TestUpsertDoesNotReplaceNewerDeletedItem(t *testing.T) {
+	conn := &upsertTestConn{hgetReply: []byte("existing")}
+	pool := &singleActiveConnectionPool{t: t, connections: []*upsertTestConn{conn}}
+	loggers := ldlog.NewDisabledLoggers()
+	loggers.SetMinLevel(ldlog.Debug)
+	store := &redisDataStoreImpl{prefix: "test", pool: pool, loggers: loggers}
+
+	updated, err := store.Upsert(fixedVersionKind{version: 2}, "flag-key", ldstoretypes.SerializedItemDescriptor{
+		Version:        1,
+		Deleted:        true,
+		SerializedItem: []byte("new"),
+	})
+
+	require.NoError(t, err)
+	require.False(t, updated)
+	require.Equal(t, 1, conn.closeCount)
+}
+
+func TestUpsertReturnsConnectionOnExecError(t *testing.T) {
+	execErr := errors.New("EXEC failed")
+	conn := &upsertTestConn{execErr: execErr}
+	pool := &singleActiveConnectionPool{t: t, connections: []*upsertTestConn{conn}}
+	store := &redisDataStoreImpl{prefix: "test", pool: pool, loggers: ldlog.NewDisabledLoggers()}
+
+	_, _ = store.Upsert(ldstoreimpl.Features(), "flag-key", ldstoretypes.SerializedItemDescriptor{
+		Version:        1,
+		SerializedItem: []byte("new"),
+	})
+
+	require.Equal(t, 1, conn.closeCount)
+	require.Zero(t, pool.activeCount)
+}
+
+type singleActiveConnectionPool struct {
+	t              *testing.T
+	connections    []*upsertTestConn
+	getCount       int
+	activeCount    int
+	maxActiveCount int
+}
+
+func (p *singleActiveConnectionPool) Get() r.Conn {
+	p.t.Helper()
+	require.Less(p.t, p.getCount, len(p.connections), "unexpected extra connection request")
+	require.Zero(p.t, p.activeCount, "Upsert requested another connection before closing the previous one")
+
+	conn := p.connections[p.getCount]
+	p.getCount++
+	p.activeCount++
+	if p.activeCount > p.maxActiveCount {
+		p.maxActiveCount = p.activeCount
+	}
+	conn.pool = p
+	return conn
+}
+
+func (p *singleActiveConnectionPool) Close() error { return nil }
+
+type upsertTestConn struct {
+	pool       *singleActiveConnectionPool
+	watchErr   error
+	hgetReply  any
+	hgetErr    error
+	hsetErr    error
+	execReply  any
+	execErr    error
+	closeCount int
+}
+
+func (c *upsertTestConn) Close() error {
+	if c.closeCount == 0 {
+		c.pool.activeCount--
+	}
+	c.closeCount++
+	return nil
+}
+
+func (c *upsertTestConn) Err() error { return nil }
+
+func (c *upsertTestConn) Do(commandName string, _ ...any) (any, error) {
+	switch commandName {
+	case "WATCH":
+		return "OK", c.watchErr
+	case "HGET":
+		if c.hgetReply == nil && c.hgetErr == nil {
+			return nil, r.ErrNil
+		}
+		return c.hgetReply, c.hgetErr
+	case "EXEC":
+		return c.execReply, c.execErr
+	default:
+		return nil, fmt.Errorf("unexpected Do command %q", commandName)
+	}
+}
+
+func (c *upsertTestConn) Send(commandName string, _ ...any) error {
+	switch commandName {
+	case "MULTI", "UNWATCH":
+		return nil
+	case "HSET":
+		return c.hsetErr
+	default:
+		return fmt.Errorf("unexpected Send command %q", commandName)
+	}
+}
+
+func (c *upsertTestConn) Flush() error { return nil }
+
+func (c *upsertTestConn) Receive() (any, error) { return nil, nil }
+
+type fixedVersionKind struct{ version int }
+
+func (k fixedVersionKind) GetName() string { return "features" }
+
+func (k fixedVersionKind) Serialize(ldstoretypes.ItemDescriptor) []byte { return nil }
+
+func (k fixedVersionKind) Deserialize([]byte) (ldstoretypes.ItemDescriptor, error) {
+	return ldstoretypes.ItemDescriptor{Version: k.version}, nil
+}


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

Limit each optimistic `Upsert` attempt to one Redis connection lifetime. When `EXEC` returns a nil response because the watched key changed, the connection is returned to the pool before the next attempt begins.

This prevents repeated conflicts from retaining one connection per attempt and eventually exhausting a bounded pool. It does not add a local or distributed lock; concurrent writers continue to coordinate through Redis's existing `WATCH`/`MULTI`/`EXEC` semantics.

**Describe alternatives you've considered**

Increasing `MaxActive` or disabling pool waiting would only delay or change the failure mode while connections continued accumulating.

A process-local mutex would reduce throughput and would not coordinate writers in other processes. A distributed lock is unnecessary because Redis already provides the required optimistic concurrency control.

Explicitly closing the connection only at the retry statement would leave future return paths vulnerable to similar lifecycle mistakes. Scoping the entire attempt ensures the connection is returned on every outcome.

**Additional context**

This follows [#39](https://github.com/launchdarkly/go-server-sdk-redis-redigo/pull/39), contributed by Alec Brickner at Plaid and released in v3.0.2. That change fixed a related deadlock by reusing the watched connection for the existing-item read instead of borrowing a second connection from the pool.

This PR addresses a separate connection-exhaustion path that remained afterward: every watch conflict retained that attempt's connection because its cleanup was deferred until `Upsert` returned. Enough retries could therefore exhaust the pool even though each individual attempt used only one connection.

The regression test uses a deterministic pool that permits only one active connection. Its first `EXEC` response simulates a watch conflict and its second succeeds. The test fails on the previous implementation when the retry requests another connection while the first remains active.

Additional scripted-connection tests exercise connection cleanup after `WATCH`, `HGET`, `HSET`, and `EXEC` errors; newer-version and deleted-item decisions; debug-enabled paths; successful transactions; and watch-conflict retries. Full-suite coverage reports 100% statement coverage for both changed functions:

    redis_impl.go:148  Upsert       100.0%
    redis_impl.go:162  tryUpsert    100.0%

<details>
<summary>Commit-by-commit regression proof</summary>

Each commit was tested against Redis with Go 1.26.5 using:

`GOEXPERIMENT=goroutineleakprofile go test -mod=readonly -race -count=1 ./...`

| Commit | Full-suite outcome | What it proves |
| --- | --- | --- |
| [`144f166`](https://github.com/dgollahon-plaid/go-server-sdk-redis-redigo/commit/144f16695b24ad3831f46382d1889b3fc1764aa8) — general transaction coverage | Pass | The additional general coverage passes against the existing implementation. |
| [`d3857de`](https://github.com/dgollahon-plaid/go-server-sdk-redis-redigo/commit/d3857deab95e832ed5b6edb7375cbaef3939930a) — regression test | Expected failure: `TestUpsertReleasesConnectionBeforeRetry` | Reproduces a retry requesting another connection while the previous connection remains checked out. |
| [`f15654c`](https://github.com/dgollahon-plaid/go-server-sdk-redis-redigo/commit/f15654c463545a30d2d0557e55c29f7c69f21e4a) — fix | Pass | Confirms each connection is returned before the next retry. |

No race or goroutine-leak findings were reported.
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Redis persistent store write path under concurrency; behavior of version checks and WATCH/MULTI/EXEC is unchanged, but incorrect connection handling could still affect availability during flag sync contention.
> 
> **Overview**
> Fixes **Redis connection pool exhaustion** when optimistic `Upsert` retries after a `WATCH` conflict (`EXEC` returns nil).
> 
> The retry loop now delegates each attempt to **`tryUpsert`**, which borrows a connection, runs `WATCH` / read / `MULTI` / `EXEC`, and **`defer`s `Close` on that attempt only**. On conflict, the attempt returns `retry=true`, the connection is returned, and the outer loop starts a fresh attempt. Previously, `defer Close` inside the `for` loop kept one checked-out connection per failed attempt until `Upsert` finished, so heavy contention could exhaust a bounded pool.
> 
> Adds **`redis_impl_upsert_retry_test.go`** with a single-active-connection mock pool to assert retries do not hold two connections, plus cases for errors, stale-version no-ops, and `EXEC` failures—all returning connections to the pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f15654c463545a30d2d0557e55c29f7c69f21e4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->