### PR TITLE
Propagate top-level Redis EXEC errors from Upsert

### DIFF
--- a/redis_impl.go
+++ b/redis_impl.go
@@ -196,14 +196,15 @@ func (store *redisDataStoreImpl) Upsert(
 		if err == nil {
 			var result interface{}
 			result, err = c.Do("EXEC")
-			if err == nil {
-				if result == nil {
-					// if exec returned nothing, it means the watch was triggered and we should retry
-					if store.loggers.IsDebugEnabled() { // COVERAGE: tests don't verify debug logging
-						store.loggers.Debug("Concurrent modification detected, retrying")
-					}
-					continue
+			if err != nil {
+				return false, err
+			}
+			if result == nil {
+				// if exec returned nothing, it means the watch was triggered and we should retry
+				if store.loggers.IsDebugEnabled() { // COVERAGE: tests don't verify debug logging
+					store.loggers.Debug("Concurrent modification detected, retrying")
 				}
+				continue
 			}
 			return true, nil
 		}

--- a/redis_impl_upsert_exec_error_test.go
+++ b/redis_impl_upsert_exec_error_test.go
@@ -13,6 +13,27 @@ import (
 	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
 )
 
+func TestUpsertReturnsExecError(t *testing.T) {
+	execErr := errors.New("EXEC failed")
+	conn := &execErrorConn{execErr: execErr}
+	pool := &scriptedConnectionPool{t: t, connections: []*execErrorConn{conn}}
+	store := &redisDataStoreImpl{
+		prefix:  "test",
+		pool:    pool,
+		loggers: ldlog.NewDisabledLoggers(),
+	}
+
+	updated, err := store.Upsert(ldstoreimpl.Features(), "flag-key", ldstoretypes.SerializedItemDescriptor{
+		Version:        1,
+		SerializedItem: []byte(`{"key":"flag-key","version":1}`),
+	})
+
+	require.False(t, updated, "a failed transaction must not be reported as an update")
+	require.ErrorIs(t, err, execErr)
+	require.Equal(t, 1, pool.getCount)
+	require.Equal(t, 1, conn.closeCount, "the connection should be returned after EXEC fails")
+}
+
 func TestUpsertReturnsConnectionOnCommandErrors(t *testing.T) {
 	watchErr := errors.New("WATCH failed")
 	hgetErr := errors.New("HGET failed")

--- a/redis_impl_upsert_exec_error_test.go
+++ b/redis_impl_upsert_exec_error_test.go
@@ -1,0 +1,161 @@
+package ldredis
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	r "github.com/gomodule/redigo/redis"
+	"github.com/stretchr/testify/require"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoreimpl"
+	"github.com/launchdarkly/go-server-sdk/v7/subsystems/ldstoretypes"
+)
+
+func TestUpsertReturnsConnectionOnCommandErrors(t *testing.T) {
+	watchErr := errors.New("WATCH failed")
+	hgetErr := errors.New("HGET failed")
+	hsetErr := errors.New("HSET failed")
+
+	tests := []struct {
+		name string
+		conn *execErrorConn
+		err  error
+	}{
+		{name: "watch", conn: &execErrorConn{watchErr: watchErr}, err: watchErr},
+		{name: "read", conn: &execErrorConn{hgetErr: hgetErr}, err: hgetErr},
+		{name: "write", conn: &execErrorConn{hsetErr: hsetErr}, err: hsetErr},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pool := &scriptedConnectionPool{t: t, connections: []*execErrorConn{test.conn}}
+			store := &redisDataStoreImpl{prefix: "test", pool: pool, loggers: ldlog.NewDisabledLoggers()}
+
+			updated, err := store.Upsert(ldstoreimpl.Features(), "flag-key", ldstoretypes.SerializedItemDescriptor{
+				Version:        1,
+				SerializedItem: []byte("new"),
+			})
+
+			require.False(t, updated)
+			require.ErrorIs(t, err, test.err)
+			require.Equal(t, 1, test.conn.closeCount)
+		})
+	}
+}
+
+func TestUpsertDoesNotReplaceNewerDeletedItem(t *testing.T) {
+	conn := &execErrorConn{hgetReply: []byte("existing")}
+	pool := &scriptedConnectionPool{t: t, connections: []*execErrorConn{conn}}
+	loggers := ldlog.NewDisabledLoggers()
+	loggers.SetMinLevel(ldlog.Debug)
+	store := &redisDataStoreImpl{prefix: "test", pool: pool, loggers: loggers}
+
+	updated, err := store.Upsert(execFixedVersionKind{version: 2}, "flag-key", ldstoretypes.SerializedItemDescriptor{
+		Version:        1,
+		Deleted:        true,
+		SerializedItem: []byte("new"),
+	})
+
+	require.NoError(t, err)
+	require.False(t, updated)
+	require.Equal(t, 1, conn.closeCount)
+}
+
+func TestUpsertRetriesWatchConflict(t *testing.T) {
+	connections := []*execErrorConn{
+		{execReply: nil},
+		{execReply: []any{[]byte("OK")}},
+	}
+	pool := &scriptedConnectionPool{t: t, connections: connections}
+	loggers := ldlog.NewDisabledLoggers()
+	loggers.SetMinLevel(ldlog.Debug)
+	store := &redisDataStoreImpl{prefix: "test", pool: pool, loggers: loggers}
+
+	updated, err := store.Upsert(ldstoreimpl.Features(), "flag-key", ldstoretypes.SerializedItemDescriptor{
+		Version:        1,
+		SerializedItem: []byte("new"),
+	})
+
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.Equal(t, 2, pool.getCount)
+	for _, conn := range connections {
+		require.Equal(t, 1, conn.closeCount)
+	}
+}
+
+type scriptedConnectionPool struct {
+	t           *testing.T
+	connections []*execErrorConn
+	getCount    int
+}
+
+func (p *scriptedConnectionPool) Get() r.Conn {
+	p.t.Helper()
+	require.Less(p.t, p.getCount, len(p.connections), "unexpected extra connection request")
+	conn := p.connections[p.getCount]
+	p.getCount++
+	return conn
+}
+
+func (p *scriptedConnectionPool) Close() error { return nil }
+
+type execErrorConn struct {
+	watchErr   error
+	hgetReply  any
+	hgetErr    error
+	hsetErr    error
+	execReply  any
+	execErr    error
+	closeCount int
+}
+
+func (c *execErrorConn) Close() error {
+	c.closeCount++
+	return nil
+}
+
+func (c *execErrorConn) Err() error { return nil }
+
+func (c *execErrorConn) Do(commandName string, _ ...any) (any, error) {
+	switch commandName {
+	case "WATCH":
+		return "OK", c.watchErr
+	case "HGET":
+		if c.hgetReply == nil && c.hgetErr == nil {
+			return nil, r.ErrNil
+		}
+		return c.hgetReply, c.hgetErr
+	case "EXEC":
+		return c.execReply, c.execErr
+	default:
+		return nil, fmt.Errorf("unexpected Do command %q", commandName)
+	}
+}
+
+func (c *execErrorConn) Send(commandName string, _ ...any) error {
+	switch commandName {
+	case "MULTI", "UNWATCH":
+		return nil
+	case "HSET":
+		return c.hsetErr
+	default:
+		return fmt.Errorf("unexpected Send command %q", commandName)
+	}
+}
+
+func (c *execErrorConn) Flush() error { return nil }
+
+func (c *execErrorConn) Receive() (any, error) { return nil, nil }
+
+type execFixedVersionKind struct{ version int }
+
+func (k execFixedVersionKind) GetName() string { return "features" }
+
+func (k execFixedVersionKind) Serialize(ldstoretypes.ItemDescriptor) []byte { return nil }
+
+func (k execFixedVersionKind) Deserialize([]byte) (ldstoretypes.ItemDescriptor, error) {
+	return ldstoretypes.ItemDescriptor{Version: k.version}, nil
+}


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

Return a non-nil error from Redigo's `Do("EXEC")` with `updated=false` instead of reporting that the update succeeded.

This is intentionally a semantic change on the transaction-error path. Successful transactions, version rejections, and nil `EXEC` responses caused by watched-key conflicts retain their existing behavior.

Propagating the error allows the Go SDK's existing persistent-store recovery behavior to run. Depending on the configured cache and status monitoring, the SDK may log the failure, mark the store unavailable, avoid updating a finite cache, wait for recovery, or restart the stream and reload its data.

**Describe alternatives you've considered**

Preserving the existing behavior would minimize compatibility risk, since it has existed since this implementation was moved out of the Go SDK in 2020. However, it reports a successful write when Redis did not confirm the transaction and bypasses the SDK's designed store-failure handling.

Silently logging the error would still tell callers that the item was updated. Returning `updated=true` with an error would also be misleading; callers should treat the update result as undefined when an error is returned.

Automatically retrying every `EXEC` error is unsafe because a transport failure can occur after Redis applied the transaction but before the client received its response. Returning the error lets the SDK perform its normal recovery. Reapplying the same update during recovery is safe because `Upsert` only writes items with a newer version.

A narrower change that propagated only Redis server errors but continued suppressing network errors would reduce observable failures, but it would preserve the most dangerous false-success case: a connection failure with an unknown transaction outcome.

**Additional context**

The regression test uses a scripted Redis connection that returns a sentinel error from `EXEC`. It verifies that `Upsert` returns the same error, reports `updated=false`, and returns the connection to the pool. It fails on the previous implementation because that implementation returns `true, nil`.

Additional scripted tests exercise `WATCH`, `HGET`, and `HSET` failures; successful transactions; watched-key conflicts and retries; version rejection; deleted items; debug-enabled paths; and connection cleanup. Full-suite coverage reports 100% statement coverage for the changed function:

    redis_impl.go:148  Upsert       100.0%

This PR is deliberately scoped to a non-nil error returned by Redigo's `Do("EXEC")`. Redigo may instead return `err=nil` with a `redis.Error` embedded in the transaction result array, such as a runtime `WRONGTYPE` failure. Detecting embedded command errors is not included in this change.

<details>
<summary>Commit-by-commit regression proof</summary>

Each commit was tested against Redis with Go 1.26.5 using:

`GOEXPERIMENT=goroutineleakprofile go test -mod=readonly -race -count=1 ./...`

| Commit | Full-suite outcome | What it proves |
| --- | --- | --- |
| [`9f51ef7`](https://github.com/dgollahon-plaid/go-server-sdk-redis-redigo/commit/9f51ef733b2f0fa6e74269d24d7a64836391c1a3) — general transaction coverage | Pass | The additional general coverage passes against the existing implementation. |
| [`735e6ba`](https://github.com/dgollahon-plaid/go-server-sdk-redis-redigo/commit/735e6ba2773bffcd80cd76d5b2c295ee9fced686) — regression test | Expected failure: `TestUpsertReturnsExecError` | Reproduces an `EXEC` failure being reported as a successful update. |
| [`116ee72`](https://github.com/dgollahon-plaid/go-server-sdk-redis-redigo/commit/116ee727d2f947cfb42d9836f41380c0eebe9e80) — fix | Pass | Confirms a top-level Redigo `EXEC` error is returned and the update is not reported as successful. |

No race or goroutine-leak findings were reported.
</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes semantics on the Redis transaction error path for persistent flag data writes, but aligns behavior with SDK recovery and avoids false-success on uncertain EXEC outcomes.
> 
> **Overview**
> **`Upsert`** now returns **`false`** and the Redigo error when **`Do("EXEC")`** fails, instead of reporting a successful update. Successful transactions, stale-version rejections, and **`nil`** **`EXEC`** results from watch conflicts are unchanged.
> 
> New scripted-connection tests cover **`EXEC`** failures, **`WATCH`/`HGET`/`HSET`** errors, version rejection, watch-conflict retries, and connection cleanup so callers and the SDK’s persistent-store recovery can treat failed Redis transactions as real failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 116ee727d2f947cfb42d9836f41380c0eebe9e80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->